### PR TITLE
Fix parseNonNullType

### DIFF
--- a/lib/utils/type-parser.js
+++ b/lib/utils/type-parser.js
@@ -32,7 +32,7 @@ function parseSimpleType(type, dependencies) {
 }
 
 function parseNonNullType(type, dependencies, next) {
-  const cleanedType = type.replace('!', '');
+  const cleanedType = type.replace(/!$/, '');
   return new graphql.GraphQLNonNull(next(cleanedType, dependencies));
 }
 


### PR DESCRIPTION
It was not working for non-null array of non-null item types when using like this
```js
'[Type!]!'
```
